### PR TITLE
fix EXDEV error on cross-device move during fxlens update

### DIFF
--- a/packages/fxhash-cli/src/updates/toolkit/fxlens.ts
+++ b/packages/fxhash-cli/src/updates/toolkit/fxlens.ts
@@ -37,8 +37,13 @@ export const fxlensUpdateConfig: ModuleUpdater = {
       recursive: true,
       force: true,
     })
-    // move download to ./lib/fxlens
-    fs.renameSync(path.join(tmpPath, "build"), path.join(FXSTUDIO_PATH))
+    // copy download to ./lib/fxlens then rm src
+    // linux /tmp usually on separate tmpfs device mount
+    // and nodejs will complain about cross-device EXDEV error if moving
+    fs.cpSync(path.join(tmpPath, "build"), path.join(FXSTUDIO_PATH), {
+      recursive: true,
+    })
+    fs.rmSync(tmpPath,{recursive:true})
     return latestVersion
   },
 }


### PR DESCRIPTION
update to copy, then rm instead of move since tmp is usually a separate mount and fs type on linux. other OS should remain unaffected

```log
Error: EXDEV: cross-device link not permitted, rename '/tmp/fxhash-cli/build' -> '/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/static/fxlens'
    at Object.renameSync (node:fs:1042:3)
    at Object.update (/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-73KLPOU4.js:183:18)
    at async /usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-73KLPOU4.js:44:23
    at async Object.step (/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-2YPNYSAB.js:101:19)
    at async /usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-73KLPOU4.js:42:32
    at async Promise.all (index 0)
    at async updateToolkit (/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-73KLPOU4.js:27:10)
    at async Object.handler (/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/dist/chunk-NBWEXRVY.js:98:7) {
  errno: -18,
  syscall: 'rename',
  code: 'EXDEV',
  path: '/tmp/fxhash-cli/build',
  dest: '/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/static/fxlens'
}
❗ EXDEV: cross-device link not permitted, rename '/tmp/fxhash-cli/build' -> '/usr/local/lib/node_modules/fxhash/node_modules/@fxhash/cli/static/fxlens'

```